### PR TITLE
Bekreftelse på om man ønsker å åpne hjelp

### DIFF
--- a/Digipost/src/main/java/no/digipost/android/gui/MainContentActivity.java
+++ b/Digipost/src/main/java/no/digipost/android/gui/MainContentActivity.java
@@ -432,14 +432,7 @@ public class MainContentActivity extends AppCompatActivity implements ContentFra
             return true;
 
         }else if (drawerListItems[content].equals(getResources().getString(R.string.drawer_help))) {
-            new AlertDialog.Builder(this).setMessage(getString(R.string.dialog_prompt_open_help_new_window))
-                .setPositiveButton(getString(R.string.yes), new DialogInterface.OnClickListener() {
-                    @Override
-                    public void onClick(DialogInterface dialog, int which) {
-                        Intent browserIntent = new Intent(Intent.ACTION_VIEW, Uri.parse(ApiConstants.URL_HELP));
-                        startActivity(browserIntent);
-                    }
-                }).setNegativeButton(getString(R.string.abort), null).show();
+            openExternalHelpUrl();
             return true;
 
         } else if (drawerListItems[content].equals(getResources().getString(R.string.drawer_logout))) {
@@ -600,6 +593,17 @@ public class MainContentActivity extends AppCompatActivity implements ContentFra
 
     private ContentFragment getCurrentFragment() {
         return (ContentFragment) getFragmentManager().findFragmentById(R.id.main_content_frame);
+    }
+
+    private void openExternalHelpUrl() {
+        new AlertDialog.Builder(this).setMessage(getString(R.string.dialog_prompt_open_help_new_window))
+                .setPositiveButton(getString(R.string.open), new DialogInterface.OnClickListener() {
+                    @Override
+                    public void onClick(DialogInterface dialog, int which) {
+                        Intent browserIntent = new Intent(Intent.ACTION_VIEW, Uri.parse(ApiConstants.URL_HELP));
+                        startActivity(browserIntent);
+                    }
+                }).setNegativeButton(getString(R.string.abort), null).show();
     }
 
     private void logOut() {

--- a/Digipost/src/main/java/no/digipost/android/gui/MainContentActivity.java
+++ b/Digipost/src/main/java/no/digipost/android/gui/MainContentActivity.java
@@ -432,8 +432,14 @@ public class MainContentActivity extends AppCompatActivity implements ContentFra
             return true;
 
         }else if (drawerListItems[content].equals(getResources().getString(R.string.drawer_help))) {
-            Intent browserIntent = new Intent(Intent.ACTION_VIEW, Uri.parse(ApiConstants.URL_HELP));
-            startActivity(browserIntent);
+            new AlertDialog.Builder(this).setMessage(getString(R.string.dialog_prompt_open_help_new_window))
+                .setPositiveButton(getString(R.string.yes), new DialogInterface.OnClickListener() {
+                    @Override
+                    public void onClick(DialogInterface dialog, int which) {
+                        Intent browserIntent = new Intent(Intent.ACTION_VIEW, Uri.parse(ApiConstants.URL_HELP));
+                        startActivity(browserIntent);
+                    }
+                }).setNegativeButton(getString(R.string.abort), null).show();
             return true;
 
         } else if (drawerListItems[content].equals(getResources().getString(R.string.drawer_logout))) {

--- a/Digipost/src/main/res/values/strings.xml
+++ b/Digipost/src/main/res/values/strings.xml
@@ -237,6 +237,8 @@
     <string name="dialog_prompt_delete_document">Vil du slette brevet?
     </string>
 
+    <string name="dialog_prompt_open_help_new_window">Hjelp vil bli åpnet i en ekstern nettleser. Fortsette?</string>
+
     <string name="dialog_edit_folder_title">Velg navn og ikon</string>
     <string name="dialog_edit_folder_invalid_folder_name">Ugyldig navn</string>
 

--- a/Digipost/src/main/res/values/strings.xml
+++ b/Digipost/src/main/res/values/strings.xml
@@ -237,7 +237,7 @@
     <string name="dialog_prompt_delete_document">Vil du slette brevet?
     </string>
 
-    <string name="dialog_prompt_open_help_new_window">Hjelp vil bli åpnet i en ekstern nettleser. Fortsette?</string>
+    <string name="dialog_prompt_open_help_new_window">Hjelpesiden vil bli åpnet i ekstern nettleser.</string>
 
     <string name="dialog_edit_folder_title">Velg navn og ikon</string>
     <string name="dialog_edit_folder_invalid_folder_name">Ugyldig navn</string>


### PR DESCRIPTION
Personlig mener jeg at det kan virke forvirrende å velge "hjelp" i menyen for så å bli redirectet fra digipost til en nettleseren.
Jeg synes derfor brukeren burde få valget om man ønsker å gå ut av digipost når det velges en lenke som åpner en ekstern applikasjon.

Såvidt jeg har erfart gjelder dette kun hjelp-elementet i menyen. Andre lenker (utenom "ny bruker") blir åpnet embeded i appen. Kanskje det heller er ønskelig oppførsel?