### PR TITLE
Endret plassering på knapper logg inn

### DIFF
--- a/Digipost/src/main/res/layout/activity_login.xml
+++ b/Digipost/src/main/res/layout/activity_login.xml
@@ -35,7 +35,7 @@
                 android:text="@string/login_idporten_login_title"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:layout_marginTop="82dp"
+                android:layout_marginTop="15dp"
                 android:id="@+id/textView4"
                 android:textSize="16sp"
                 android:layout_below="@+id/login_passwordButton"
@@ -120,7 +120,7 @@
                 android:layout_marginTop="10dp"
                 android:textColor="@color/black_subject"
                 android:id="@+id/login_forgotPasswordButton"
-                android:textSize="14sp" android:layout_below="@+id/login_passwordButton" android:layout_alignLeft="@+id/login_passwordButton" android:layout_alignStart="@+id/login_passwordButton"/>
+                android:textSize="14sp" android:layout_below="@+id/login_idportenButton" android:layout_alignLeft="@+id/login_passwordButton" android:layout_alignStart="@+id/login_passwordButton"/>
         <Button
                 android:text="@string/login_registrationbutton_text"
                 android:layout_width="wrap_content"


### PR DESCRIPTION
Forslag til endring for mer "flyt" i designet.
Tidligere var "Glemt passord" og "Ny bruker" plassert imellom "Logg inn med passord"-knappen  og "Logg inn med elektronsik ID"

![digipost_new_login_screen](https://cloud.githubusercontent.com/assets/10381866/25195809/0e76764e-253f-11e7-82b7-6e1d4e29087e.png)
