### PR TITLE
Vis hele emnefeltet (også når dette utvides til 256 tegn)

### DIFF
--- a/Digipost/build.gradle
+++ b/Digipost/build.gradle
@@ -3,8 +3,8 @@ apply plugin: 'com.android.application'
 
 android {
     defaultConfig {
-        versionCode 60
-        versionName '3.3.1'
+        versionCode 61
+        versionName '3.3.2'
         applicationId = "no.digipost.android"
         minSdkVersion 16
         targetSdkVersion 25

--- a/Digipost/src/main/java/no/digipost/android/gui/content/DisplayContentActivity.java
+++ b/Digipost/src/main/java/no/digipost/android/gui/content/DisplayContentActivity.java
@@ -184,13 +184,23 @@ public abstract class DisplayContentActivity extends AppCompatActivity {
     }
 
     protected void showInformationDialog() {
-        String documentSubject = DocumentContentStore.getDocumentParent() != null ? DocumentContentStore.getDocumentParent().getSubject() : "";
-        String attachmentSubject = DocumentContentStore.getDocumentAttachment() != null ? DocumentContentStore.getDocumentAttachment().getSubject() : "";
-        new AlertDialog.Builder(this).setMessage(formatInfoText(documentSubject, attachmentSubject)).setNegativeButton(getString(R.string.close), null).show();
+        if (content_type != ApplicationConstants.RECEIPTS && DocumentContentStore.getDocumentParent() != null && DocumentContentStore.getDocumentAttachment() != null) {
+            new AlertDialog.Builder(this).setMessage(getFormattedInfoText()).setNegativeButton(getString(R.string.close), null).show();
+        }
     }
 
-    private Spanned formatInfoText(final String documentSubject, final String attachmentSubject){
-        String infoText = documentSubject.equals(attachmentSubject) ? String.format("<b>%1$s</b>", documentSubject) : String.format("<b> %1$s </b> <br><br> %2$s ", documentSubject,attachmentSubject);
+    private Spanned getFormattedInfoText(){
+        String documentSubject = DocumentContentStore.getDocumentParent().getSubject();
+        String attachmentSubject = DocumentContentStore.getDocumentAttachment().getSubject();
+
+        String infoText = String.format("<b>%1$s</b>", documentSubject);
+
+        if(!attachmentSubject.equals(documentSubject)) {
+            infoText += String.format("<br><br> %1$s ", DocumentContentStore.getDocumentAttachment().getSubject());
+        }
+
+        infoText += String.format("<br><br> %1$s", DocumentContentStore.getDocumentParent().getCreatorName());
+
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
             return Html.fromHtml(infoText,Html.FROM_HTML_MODE_LEGACY);
         }else{
@@ -258,10 +268,9 @@ public abstract class DisplayContentActivity extends AppCompatActivity {
         finish();
     }
 
-    public void setActionBar(String title, String subTitle) {
+    public void setActionBar(String title) {
         if(getSupportActionBar()!=null) {
             getSupportActionBar().setTitle(title);
-            getSupportActionBar().setSubtitle(subTitle);
             getSupportActionBar().setHomeButtonEnabled(true);
         }
     }

--- a/Digipost/src/main/java/no/digipost/android/gui/content/DisplayContentActivity.java
+++ b/Digipost/src/main/java/no/digipost/android/gui/content/DisplayContentActivity.java
@@ -16,6 +16,7 @@
 
 package no.digipost.android.gui.content;
 
+import android.app.ActionBar;
 import android.app.Activity;
 import android.app.AlertDialog;
 import android.app.ProgressDialog;
@@ -23,9 +24,14 @@ import android.content.ActivityNotFoundException;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
+import android.net.Uri;
 import android.os.AsyncTask;
+import android.os.Build;
 import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
+import android.support.v7.widget.Toolbar;
+import android.text.Html;
+import android.text.Spanned;
 import android.util.Log;
 import android.view.Gravity;
 import android.view.LayoutInflater;
@@ -175,6 +181,21 @@ public abstract class DisplayContentActivity extends AppCompatActivity {
         Intent i = new Intent(activity, InvoiceOptionsActivity.class);
         i.putExtra(InvoiceOptionsActivity.INTENT_ACTIONBAR_TITLE, invoiceSubject);
         activity.startActivity(i);
+    }
+
+    protected void showInformationDialog() {
+        String documentSubject = DocumentContentStore.getDocumentParent() != null ? DocumentContentStore.getDocumentParent().getSubject() : "";
+        String attachmentSubject = DocumentContentStore.getDocumentAttachment() != null ? DocumentContentStore.getDocumentAttachment().getSubject() : "";
+        new AlertDialog.Builder(this).setMessage(formatInfoText(documentSubject, attachmentSubject)).setNegativeButton(getString(R.string.close), null).show();
+    }
+
+    private Spanned formatInfoText(final String documentSubject, final String attachmentSubject){
+        String infoText = documentSubject.equals(attachmentSubject) ? String.format("<b>%1$s</b>", documentSubject) : String.format("<b> %1$s </b> <br><br> %2$s ", documentSubject,attachmentSubject);
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+            return Html.fromHtml(infoText,Html.FROM_HTML_MODE_LEGACY);
+        }else{
+            return Html.fromHtml(infoText);
+        }
     }
 
     protected void deleteAction(final Activity originActivity) {

--- a/Digipost/src/main/java/no/digipost/android/gui/content/HtmlAndReceiptActivity.java
+++ b/Digipost/src/main/java/no/digipost/android/gui/content/HtmlAndReceiptActivity.java
@@ -21,6 +21,7 @@ import android.support.v7.widget.Toolbar;
 import android.view.Menu;
 import android.view.MenuInflater;
 import android.view.MenuItem;
+import android.view.View;
 import android.webkit.WebView;
 import com.google.android.gms.analytics.GoogleAnalytics;
 import no.digipost.android.DigipostApplication;
@@ -44,6 +45,12 @@ public class HtmlAndReceiptActivity extends DisplayContentActivity {
         setContentView(R.layout.activity_html_and_receipt);
         Toolbar toolbar = (Toolbar) findViewById(R.id.toolbar);
         setSupportActionBar(toolbar);
+        toolbar.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                showInformationDialog();
+            }
+        });
         getSupportActionBar().setDisplayHomeAsUpEnabled(true);
         setupWebView();
         setupActionBar();
@@ -84,17 +91,17 @@ public class HtmlAndReceiptActivity extends DisplayContentActivity {
     public boolean onCreateOptionsMenu(Menu menu) {
         MenuInflater inflater = getMenuInflater();
         inflater.inflate(R.menu.activity_html_actionbar, menu);
-
         return super.onCreateOptionsMenu(menu);
     }
 
     @Override
     public boolean onPrepareOptionsMenu(Menu menu) {
         sendToBank = menu.findItem(R.id.htmlmenu_send_to_bank);
-        MenuItem move = menu.findItem(R.id.htmlmenu_move);
 
         if (content_type != ApplicationConstants.RECEIPTS) {
-            move.setVisible(true);
+            menu.findItem(R.id.htmlmenu_move).setVisible(true);
+        }else{
+            menu.findItem(R.id.htmlmenu_info).setVisible(false);
         }
 
         boolean sendToBankVisible = getIntent().getBooleanExtra(ContentFragment.INTENT_SEND_TO_BANK, false);
@@ -120,6 +127,9 @@ public class HtmlAndReceiptActivity extends DisplayContentActivity {
                 return true;
             case R.id.htmlmenu_move:
                 showMoveToFolderDialog();
+                return true;
+            case R.id.htmlmenu_info:
+                showInformationDialog();
                 return true;
         }
 

--- a/Digipost/src/main/java/no/digipost/android/gui/content/HtmlAndReceiptActivity.java
+++ b/Digipost/src/main/java/no/digipost/android/gui/content/HtmlAndReceiptActivity.java
@@ -151,8 +151,7 @@ public class HtmlAndReceiptActivity extends DisplayContentActivity {
             if(getSupportActionBar() != null) {
                 if (content_type != ApplicationConstants.RECEIPTS) {
                     Attachment documentMeta = DocumentContentStore.getDocumentAttachment();
-                    getSupportActionBar().setTitle(documentMeta.getSubject());
-                    getSupportActionBar().setSubtitle(DocumentContentStore.getDocumentParent().getCreatorName());
+                    setActionBar(documentMeta.getSubject());
                 } else {
                     Receipt receiptMeta = DocumentContentStore.getDocumentReceipt();
                     getSupportActionBar().setTitle(receiptMeta.getStoreName());

--- a/Digipost/src/main/java/no/digipost/android/gui/content/MuPDFActivity.java
+++ b/Digipost/src/main/java/no/digipost/android/gui/content/MuPDFActivity.java
@@ -219,6 +219,12 @@ public class MuPDFActivity extends DisplayContentActivity {
         Toolbar toolbar = (Toolbar) findViewById(R.id.toolbar);
         setSupportActionBar(toolbar);
         getSupportActionBar().setDisplayHomeAsUpEnabled(true);
+        toolbar.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                showInformationDialog();
+            }
+        });
         ((DigipostApplication) getApplication()).getTracker(DigipostApplication.TrackerName.APP_TRACKER);
         selectActionModeCallback = new SelectActionModeCallback();
         mAlertBuilder = new AlertDialog.Builder(this);

--- a/Digipost/src/main/java/no/digipost/android/gui/content/MuPDFActivity.java
+++ b/Digipost/src/main/java/no/digipost/android/gui/content/MuPDFActivity.java
@@ -529,6 +529,9 @@ public class MuPDFActivity extends DisplayContentActivity {
             case R.id.pdfmenu_save:
                 super.downloadFile();
                 return true;
+            case R.id.htmlmenu_info:
+                showInformationDialog();
+                return true;
         }
 
         return super.onOptionsItemSelected(item);

--- a/Digipost/src/main/res/layout/content_list_item.xml
+++ b/Digipost/src/main/res/layout/content_list_item.xml
@@ -80,8 +80,7 @@
                 android:ellipsize="end"
                 android:maxLines="1"
                 android:textColor="@color/black_subject"
-                android:text="Eiendomsskatt"
-                android:textSize="18sp"/>
+                android:textSize="16sp"/>
 
         <TextView
                 android:id="@+id/content_subTitle"
@@ -91,7 +90,6 @@
                 android:layout_marginTop="3sp"
                 android:ellipsize="end"
                 android:maxLines="1"
-                android:text="Oslo Kommune"
                 android:textColor="@color/grey_creator"
                 android:textSize="14sp"/>
 
@@ -103,7 +101,6 @@
                 android:layout_marginTop="3sp"
                 android:ellipsize="end"
                 android:maxLines="1"
-                android:text="Faktura: Lagt til betaling"
                 android:textColor="@color/grey_creator"
                 android:textSize="14sp"/>
     </LinearLayout>

--- a/Digipost/src/main/res/menu/activity_html_actionbar.xml
+++ b/Digipost/src/main/res/menu/activity_html_actionbar.xml
@@ -20,4 +20,9 @@
             android:visible="false"
             android:showAsAction="never"/>
 
+    <item
+            android:id="@+id/htmlmenu_info"
+            android:title="@string/information"
+            android:showAsAction="ifRoom"/>
+
 </menu>

--- a/Digipost/src/main/res/menu/activity_mupdf_actionbar.xml
+++ b/Digipost/src/main/res/menu/activity_mupdf_actionbar.xml
@@ -42,4 +42,10 @@
             android:title="@string/save_to_device">
     </item>
 
+    <item
+            android:id="@+id/htmlmenu_info"
+            android:title="@string/information"
+            app:showAsAction="never">
+    </item>
+
 </menu>

--- a/Digipost/src/main/res/values/strings.xml
+++ b/Digipost/src/main/res/values/strings.xml
@@ -216,7 +216,7 @@
         igjen.
     </string>
     <string name="error_digipost_api">En feil oppstod under oppkoblingen mot Digipost.</string>
-    <string name="error_invalid_token">Tilgang utløpt, vennligst logg inn på nytt</string>
+    <string name="error_invalid_token">Innloggingen din har utløpt. Logg inn på nytt.</string>
     <string name="error_bad_request">Beklager, en feil har oppstått. Vennligst prøv igjen.</string>
     <string name="error_inputstreamtobyarray">En feil oppstod under åpning av innhold</string>
     <string name="error_no_activity_to_open_file">Du har ingen apper som kan åpne

--- a/Digipost/src/main/res/values/strings.xml
+++ b/Digipost/src/main/res/values/strings.xml
@@ -78,6 +78,7 @@
     <string name="saving">Lagrer…</string>
     <string name="uploaded">Opplastet</string>
     <string name="public_entity">Offentlig: %s</string>
+    <string name="information">Informasjon</string>
 
     <string name="move_checkbox_description">Avhukingsboks for å velge flere listeelementer til mengdeoperasjoner, som flytt og slett</string>
 


### PR DESCRIPTION
Det ble besluttet at dette kun vises inne på documentvisning. Bruker kan klikke på header eller på knappen "informasjon" i meny. Da vises tittel på Document og tittel på Vedlegg(om dette er forskjellig). I tillegg vises navn på avsender. 


<img width="430" alt="okt feltlengde" src="https://cloud.githubusercontent.com/assets/681234/25708100/c750f296-30e5-11e7-8bf1-6eb65c37b861.png">
