### PR TITLE
WebView ID-porten bugfix

### DIFF
--- a/Digipost/build.gradle
+++ b/Digipost/build.gradle
@@ -3,8 +3,8 @@ apply plugin: 'com.android.application'
 
 android {
     defaultConfig {
-        versionCode 67
-        versionName '3.3.7'
+        versionCode 68
+        versionName '3.3.8'
         applicationId = "no.digipost.android"
         minSdkVersion 16
         targetSdkVersion 25
@@ -56,12 +56,12 @@ android {
 }
 
 buildscript {
-    
+
     repositories {
         jcenter()
         mavenCentral()
     }
-    
+
     dependencies {
         classpath 'com.android.tools.build:gradle:2.3.0'
     }

--- a/Digipost/build.gradle
+++ b/Digipost/build.gradle
@@ -3,8 +3,8 @@ apply plugin: 'com.android.application'
 
 android {
     defaultConfig {
-        versionCode 68
-        versionName '3.3.8'
+        versionCode 69
+        versionName '3.3.9'
         applicationId = "no.digipost.android"
         minSdkVersion 16
         targetSdkVersion 25

--- a/Digipost/src/main/java/no/digipost/android/gui/WebLoginActivity.java
+++ b/Digipost/src/main/java/no/digipost/android/gui/WebLoginActivity.java
@@ -83,7 +83,6 @@ public class WebLoginActivity extends AppCompatActivity {
         webView.setScrollBarStyle(WebView.SCROLLBARS_OUTSIDE_OVERLAY);
         webView.setScrollbarFadingEnabled(true);
         webView.setWebViewClient(new MyWebViewClient());
-        webView.setLayerType(View.LAYER_TYPE_SOFTWARE, null);
     }
 
     private void setAuthenticationScope(Bundle extras){

--- a/Digipost/src/main/java/no/digipost/android/gui/WebLoginActivity.java
+++ b/Digipost/src/main/java/no/digipost/android/gui/WebLoginActivity.java
@@ -50,11 +50,6 @@ public class WebLoginActivity extends AppCompatActivity {
         super.onCreate(savedInstanceState);
         ((DigipostApplication) getApplication()).getTracker(DigipostApplication.TrackerName.APP_TRACKER);
         setContentView(R.layout.fragment_login_webview);
-    }
-
-    @Override
-    protected void onStart() {
-        super.onStart();
         setAuthenticationScope(getIntent().getExtras());
         checkIfAppIsOnline();
         WebView webView = (WebView) findViewById(R.id.login_webview);
@@ -64,7 +59,6 @@ public class WebLoginActivity extends AppCompatActivity {
         setSupportActionBar(toolbar);
         getSupportActionBar().setTitle("Avbryt");
         getSupportActionBar().setDisplayHomeAsUpEnabled(true);
-
     }
 
     private void setupWebView(WebView webView){


### PR DESCRIPTION
Skrur av eksplisitt software rendring av webview brukt til login og flytter all logikk til onCreate. Dette retter problemer med innloggingsproblemer med rendring, og en bug med ID-porten-loop som ble introdusert forrige onsdag. Gjenskapt, testet og verifisert på emulator og device via beta.