### PR TITLE
Fikser at mobilnummer ble gjemt av tastatur på noen skjermer

### DIFF
--- a/Digipost/src/main/res/layout/activity_notification_settings.xml
+++ b/Digipost/src/main/res/layout/activity_notification_settings.xml
@@ -89,7 +89,8 @@
                 <LinearLayout
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:orientation="horizontal">
+                    android:orientation="horizontal"
+                    android:layout_marginBottom="80dp">
 
                     <EditText
                         android:id="@+id/notification_settings_countrycode"


### PR DESCRIPTION
Litt hackish, men gjør scrollviewet litt større slik at tastaturet korrekt viser input-feltet
Før:
<img width="343" alt="screenshot 2018-11-26 at 13 46 15" src="https://user-images.githubusercontent.com/10381866/49016600-dd915100-f186-11e8-8330-ae0722309317.png">

Etter:
<img width="342" alt="screenshot 2018-11-26 at 14 26 19" src="https://user-images.githubusercontent.com/10381866/49016734-47115f80-f187-11e8-8f11-3edb2498ff6e.png">
